### PR TITLE
Add command for adding metadata to an existing NPZ file

### DIFF
--- a/src/lmcontrol/__init__.py
+++ b/src/lmcontrol/__init__.py
@@ -17,13 +17,14 @@ def main():
     command_dict = {
         'Segmentation': {
             'crop': Command('segment.main', 'Crop light microscopy images to bounding box around single cell'),
+            'add-md': Command('segment.add_metadata', 'Add metadata to cropped image package'),
             'prep-viz': Command('viz.make_package.main', 'Prepare package for visualizing image embeddings'),
             'emb-viz': Command('viz.interactive_viz.main', 'Interactive viewer of image embeddings'),
         },
         'Self-supervised Learning': {
             'train-byol': Command('nn.byol.train', 'Train BYOL model'),
             'infer-byol': Command('nn.byol.predict', 'Run with inference BYOL backbone'),
-            
+
         },
         'Supervised Learning':{
             'tune': Command('nn.clf.tune', 'Run HPO for classifier or regressor with Optuna'),

--- a/src/lmcontrol/segment.py
+++ b/src/lmcontrol/segment.py
@@ -186,6 +186,18 @@ def metadata(string):
     return dict()
 
 
+def add_metadata(argv=None):
+    parser = argparse.ArgumentParser(description="Add metadata to a NPZ file produced by the crop command")
+    parser.add_argument("npz", type=str, help='Path to the NPZ file')
+    parser.add_argument("metadata", help="a comma-separated list of key=value pairs. e.g. ht=1,time=S4", default="", type=metadata)
+    args = parser.parse_args(argv)
+
+    npz = np.load(args.npz)
+    data = dict(npz)
+    data.update(args.metadata)
+    np.savez(args.npz, **data)
+
+
 def main(argv=None):
     """
     Segment and images in a directory, saving segmented images to a


### PR DESCRIPTION
```bash
usage: lmcontrol add-md [-h] npz metadata

Add metadata to a NPZ file produced by the crop command

positional arguments:
  npz         Path to the NPZ file
  metadata    a comma-separated list of key=value pairs. e.g. ht=1,time=S4

options:
  -h, --help  show this help message and exit
```